### PR TITLE
Refactor crypto modules and update test structure for consistency

### DIFF
--- a/core/src/main/scala/cryptic/crypto/Caesar.scala
+++ b/core/src/main/scala/cryptic/crypto/Caesar.scala
@@ -19,7 +19,7 @@ object Caesar:
   case class Key(offset: Int):
     require(offset != 0)
   given encrypt(using key: Key): Encrypt = (plainText: PlainText) =>
-    val bytes = plainText.map(b ⇒ (b + key.offset).toByte)
+    val bytes = plainText.bytes.map(b ⇒ (b + key.offset).toByte)
     CipherText(bytes)
   given decrypt(using key: Key): Decrypt = (cipherText: CipherText) =>
     Try[PlainText](

--- a/core/src/main/scala/cryptic/crypto/Reverse.scala
+++ b/core/src/main/scala/cryptic/crypto/Reverse.scala
@@ -17,6 +17,6 @@ import scala.util.Success
   */
 object Reverse:
   given encrypt: Encrypt = (plainText: PlainText) =>
-    CipherText(plainText.reverse)
+    CipherText(plainText.bytes.reverse)
   given decrypt: Decrypt = (cipherText: CipherText) =>
     Success(PlainText(cipherText.bytes.reverse))

--- a/core/src/main/scala/cryptic/package.scala
+++ b/core/src/main/scala/cryptic/package.scala
@@ -3,27 +3,43 @@ import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 
 package object cryptic:
-  type PlainText = Array[Byte]
   type Hash = Vector[Byte]
+  type Manifest = Array[Byte]
+  object Manifest:
+    val empty: Array[Byte] = Array.emptyByteArray
+  case class PlainText(bytes: Array[Byte], manifest: Manifest = Manifest.empty):
+//    override def toString: String = "\uD83D\uDD12"
+
+    override def equals(obj: Any): Boolean = obj match
+      case other: PlainText =>
+        manifest.sameElements(other.manifest) && bytes.sameElements(other.bytes)
+      case _ => false
+
+    override def hashCode: Int =
+      java.util.Arrays.hashCode(bytes) * 31 + java.util.Arrays.hashCode(
+        manifest
+      )
+
   object PlainText:
-    val Empty: PlainText = PlainText(Array.emptyByteArray)
-    def apply(x: Array[Byte]): PlainText = x
-    def apply(x: String): PlainText = x.getBytes()
+    val empty: PlainText = PlainText(Array.emptyByteArray)
+    def apply(x: Array[Byte]): PlainText = new PlainText(x)
+    def apply(x: String): PlainText = apply(x.getBytes())
     def apply(x: Int): PlainText =
       val buffer = ByteBuffer.allocate(4)
       buffer.putInt(x)
-      buffer.array()
+      apply(buffer.array())
+
     def apply(x: Long): PlainText =
       val buffer = ByteBuffer.allocate(8)
       buffer.putLong(x)
-      buffer.array()
+      apply(buffer.array())
     def apply(x: Double): PlainText =
       val buffer = ByteBuffer.allocate(8)
       buffer.putDouble(x)
-      buffer.array()
+      apply(buffer.array())
     def unapply[T](plainText: PlainText)(using ct: ClassTag[T]): Try[T] =
       def checkSize(n: Int): Try[PlainText] =
-        if plainText.length == n then Success(plainText)
+        if plainText.bytes.length == n then Success(plainText)
         else
           Failure(
             new IllegalArgumentException(
@@ -32,13 +48,19 @@ package object cryptic:
           )
       ct.runtimeClass match
         case c if c == classOf[String] =>
-          Try(new String(plainText).trim.asInstanceOf[T])
+          Try(new String(plainText.bytes).trim.asInstanceOf[T])
         case c if c == classOf[Int] =>
-          checkSize(4).map(ByteBuffer.wrap(_).getInt.asInstanceOf[T])
+          checkSize(4).map(plainText =>
+            ByteBuffer.wrap(plainText.bytes).getInt.asInstanceOf[T]
+          )
         case c if c == classOf[Double] =>
-          checkSize(8).map(ByteBuffer.wrap(_).getDouble.asInstanceOf[T])
+          checkSize(8).map(plainText =>
+            ByteBuffer.wrap(plainText.bytes).getDouble.asInstanceOf[T]
+          )
         case c if c == classOf[Long] =>
-          checkSize(8).map(ByteBuffer.wrap(_).getLong.asInstanceOf[T])
+          checkSize(8).map(plainText =>
+            ByteBuffer.wrap(plainText.bytes).getLong.asInstanceOf[T]
+          )
         case _ =>
           Failure(
             new IllegalArgumentException(
@@ -50,8 +72,10 @@ package object cryptic:
   def hash(plainText: PlainText): Hash =
     import java.security.MessageDigest
     val digest = MessageDigest.getInstance("SHA-256")
-    digest.digest(plainText).toVector
+    digest.digest(plainText.bytes).toVector // Todo handle manifest?
   case class CipherText(bytes: Array[Byte]):
+    def buffer: ByteBuffer = ByteBuffer.wrap(bytes)
+    def split: Array[Array[Byte]] = buffer.split
     override def equals(obj: scala.Any): Boolean = obj match
       case CipherText(other) ⇒ bytes.sameElements(other)
       case _ ⇒ false
@@ -59,12 +83,23 @@ package object cryptic:
       s"${getClass.getCanonicalName.split('.').last}(0x${bytes.map("%02x".format(_)).mkString})"
   object CipherText:
     val Empty: CipherText = CipherText(Array.emptyByteArray)
+    def apply(array: Array[Byte], arrays: Array[Byte]*): CipherText =
+      val count = 1 + arrays.length
+      val buffer = ByteBuffer.allocate(4 + count * 4 + arrays.foldLeft(0):
+        case (length, bytes) => length + bytes.length)
+      buffer.putInt(count)
+      buffer.nextBytes(array)
+      arrays.foldLeft(buffer):
+        case (buffer, bytes) => buffer.nextBytes(bytes)
+      new CipherText(buffer.array())
+    def unapplySeq(cipherText: CipherText): Option[Seq[Array[Byte]]] =
+      Option(cipherText.split)
   object Encrypt:
     val Empty: Encrypt = _ ⇒ CipherText.Empty
   trait Encrypt:
     def apply(plainText: PlainText): CipherText
   object Decrypt:
-    val Empty: Decrypt = _ ⇒ Success(PlainText.Empty)
+    val Empty: Decrypt = _ ⇒ Success(PlainText.empty)
   trait Decrypt:
     def apply(cipherText: CipherText): Try[PlainText]
   trait Serializer[V]:
@@ -79,12 +114,12 @@ package object cryptic:
   given bytesSerializer: Serializer[Array[Byte]] = new Serializer[Array[Byte]]:
     override def serialize(value: Array[Byte]): PlainText = PlainText(value)
     override def deserialize(plainText: PlainText): Try[Array[Byte]] = Try(
-      plainText.array
+      plainText.bytes
     )
   given stringSerializer: Serializer[String] = new Serializer[String]:
     override def serialize(value: String): PlainText = PlainText(value)
     override def deserialize(plainText: PlainText): Try[String] = Try(
-      new String(plainText)
+      new String(plainText.bytes)
     )
   given intSerializer: Serializer[Int] = new Serializer[Int]:
     override def serialize(value: Int): PlainText = PlainText(value)
@@ -98,9 +133,22 @@ package object cryptic:
     override def serialize(value: Double): PlainText = PlainText(value)
     override def deserialize(plainText: PlainText): Try[Double] =
       PlainText.unapply[Double](plainText)
-//  given defaultSerializer[V: ClassTag]: Serializer[V] = new Serializer[V]:
-//    override def serialize(value: V): PlainText = PlainText(value)
-//    override def deserialize(plainText: PlainText): Try[V] =
-//      PlainText.unapply[V](plainText)
+
   extension [V: Serializer](value: V)
     def encrypted(using encrypt: Encrypt): Encrypted[V] = Encrypted(value)
+
+  extension (buffer: ByteBuffer)
+    def nextBytes(): Array[Byte] =
+      val length = buffer.getInt()
+      val bytes =
+        if length == 0 then Array.emptyByteArray else new Array[Byte](length)
+      buffer.get(bytes)
+      bytes
+    def nextBytes(bytes: Array[Byte]): ByteBuffer =
+      buffer.putInt(bytes.length)
+      buffer.put(bytes)
+    def split: Array[Array[Byte]] =
+      val count = buffer.getInt()
+      val arrays = Array.ofDim[Array[Byte]](count)
+      for i <- 0 until count do arrays(i) = buffer.nextBytes()
+      arrays

--- a/core/src/test/scala/app/ReverseAppSpec.scala
+++ b/core/src/test/scala/app/ReverseAppSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.TryValues
 
 import scala.util.{Success, Try}
 
-class AppSpec extends AnyFlatSpec with Matchers with TryValues:
+class ReverseAppSpec extends AnyFlatSpec with Matchers with TryValues:
   import cryptic.{*, given}
   import cryptic.crypto.Reverse.given
 

--- a/core/src/test/scala/app/ReverseAppSpec.scala
+++ b/core/src/test/scala/app/ReverseAppSpec.scala
@@ -31,7 +31,7 @@ class ReverseAppSpec extends AnyFlatSpec with Matchers with TryValues:
     person.toString shouldBe "Person(17,Encrypted(CipherText(0x67726f2e6f7470797263616c616373406e697472616d)))"
 
   "PlainText" should "be easy" in:
-    PlainText(clear) shouldBe clear.getBytes()
+    PlainText(clear).bytes shouldBe clear.getBytes()
     val enc = clear.encrypted
     enc.bytes shouldBe clear.getBytes.reverse
 

--- a/crypto-bouncycastle/src/main/scala/cryptic/crypto/EC.scala
+++ b/crypto-bouncycastle/src/main/scala/cryptic/crypto/EC.scala
@@ -18,12 +18,13 @@ object EC:
   given encrypt(using key: PublicKey): Encrypt =
     (plainText: PlainText) =>
       cipher.init(Cipher.ENCRYPT_MODE, key)
-      CipherText(cipher.doFinal(plainText))
+      CipherText(plainText.manifest, cipher.doFinal(plainText.bytes))
 
   given decrypt(using key: PrivateKey): Decrypt =
     (cipherText: CipherText) =>
+      val Array(manifest, bytes) = cipherText.split
       cipher.init(Cipher.DECRYPT_MODE, key)
-      Try[PlainText](PlainText(cipher.doFinal(cipherText.bytes)))
+      Try[PlainText](PlainText(cipher.doFinal(bytes), manifest))
 
   /** Generates a new elliptic curve key pair.
     *

--- a/crypto-bouncycastle/src/test/scala/app/ECAppSpec.scala
+++ b/crypto-bouncycastle/src/test/scala/app/ECAppSpec.scala
@@ -1,0 +1,36 @@
+package app
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.TryValues
+
+import java.security.{KeyPair, PrivateKey, PublicKey}
+import scala.util.{Success, Try}
+
+class ECAppSpec extends AnyFlatSpec with Matchers with TryValues:
+  import cryptic.{*, given}
+  import cryptic.crypto.EC.{*, given}
+
+  val keyPair: KeyPair = keygen(256)
+  given publicKey: PublicKey = keyPair.getPublic
+  given privateKey: PrivateKey = keyPair.getPrivate
+
+  val clear = "secret"
+  val encrypted: Encrypted[String] = clear.encrypted
+  val decrypted: Try[String] = encrypted.decrypted
+
+  "Cryptic" should "encrypt" in:
+    encrypted.bytes should not equal clear.getBytes
+
+  "Cryptic" should "decrypt" in:
+    decrypted.success shouldEqual Success(clear)
+
+  case class Person(id: Long, email: Encrypted[String])
+
+  "Person" should "handle encryption" in:
+    val id = 17
+    val email = "martin@scalacrypto.org"
+    val person = Person(id, email.encrypted)
+    person.email.bytes should not equal email.getBytes()
+    person.email.contains(email) shouldBe true
+    person.toString should startWith("Person(17,Encrypted(CipherText(0x")

--- a/crypto-javax/src/main/scala/cryptic/crypto/RSA.scala
+++ b/crypto-javax/src/main/scala/cryptic/crypto/RSA.scala
@@ -22,12 +22,13 @@ object RSA:
   given encrypt(using key: PublicKey): Encrypt =
     (plainText: PlainText) =>
       cipher.init(Cipher.ENCRYPT_MODE, key)
-      CipherText(cipher.doFinal(plainText))
+      CipherText(plainText.manifest, cipher.doFinal(plainText.bytes))
 
   given decrypt(using key: PrivateKey): Decrypt =
     (cipherText: CipherText) =>
+      val Array(manifest, bytes) = cipherText.split
       cipher.init(Cipher.DECRYPT_MODE, key)
-      Try[PlainText](PlainText(cipher.doFinal(cipherText.bytes)))
+      Try[PlainText](PlainText(cipher.doFinal(bytes), manifest))
 
   /** Generates a new RSA key pair with the specified key size.
     *

--- a/crypto-test/src/test/scala/cryptic/serialization/EncryptedSpec.scala
+++ b/crypto-test/src/test/scala/cryptic/serialization/EncryptedSpec.scala
@@ -36,13 +36,13 @@ trait EncryptedSpecBase extends AnyFlatSpec with Matchers with EitherValues:
 
   "Case class with encrypted members" should "encrypt and decrypt" in:
     val foo = FooBar("secret".encrypted)
-    foo.secret.bytes shouldEqual serializer[String].serialize("secret").reverse
+    foo.secret.bytes shouldEqual serializer[String].serialize("secret").bytes.reverse
     foo.secret.decrypted shouldEqual Success("secret")
   "Encrypted case class with" should "encrypt and decrypt" in:
     val foo = Foo("clear")
     val encryptedFoo = foo.encrypted
     val plainText = serializer[Foo].serialize(foo)
-    encryptedFoo.bytes shouldBe plainText.reverse // Reveres crypto
+    encryptedFoo.bytes shouldBe plainText.bytes.reverse // Reveres crypto
     encryptedFoo.decrypted shouldEqual Success(foo)
   "Pending operations " should " be ran when decrypting" in:
     val encrypted: Encrypted[String] = "secret".encrypted

--- a/serialization-chill/src/main/scala/cryptic/serialization/Chill.scala
+++ b/serialization-chill/src/main/scala/cryptic/serialization/Chill.scala
@@ -22,6 +22,6 @@ object Chill:
     KryoPool.withByteArrayOutputStream(10, new ScalaKryoInstantiator())
 
   given serializer[V]: Serializer[V] = new Serializer[V]:
-    def serialize(value: V): PlainText = kryoPool.toBytesWithClass(value)
+    def serialize(value: V): PlainText = PlainText(kryoPool.toBytesWithClass(value))
     def deserialize(plainText: PlainText): Try[V] = Try:
-      kryoPool.fromBytes(plainText).asInstanceOf[V]
+      kryoPool.fromBytes(plainText.bytes).asInstanceOf[V]

--- a/serialization-fst/src/main/scala/cryptic/serialization/Fst.scala
+++ b/serialization-fst/src/main/scala/cryptic/serialization/Fst.scala
@@ -33,5 +33,5 @@ object Fst:
       fst.asByteArray(value)
     )
     override def deserialize(plainText: PlainText): Try[V] = Try(
-      fst.asObject(plainText).asInstanceOf[V]
+      fst.asObject(plainText.bytes).asInstanceOf[V]
     )

--- a/serialization-upickle/src/main/scala/cryptic/serialization/Upickle.scala
+++ b/serialization-upickle/src/main/scala/cryptic/serialization/Upickle.scala
@@ -18,5 +18,5 @@ object Upickle:
     new Serializer[V]:
       override def serialize(value: V): PlainText = PlainText(write(value))
       override def deserialize(plainText: PlainText): Try[V] = Try(
-        read[V](plainText)
+        read[V](plainText.bytes)
       )


### PR DESCRIPTION
* Refactor test structure: replace `AppSpec` with `ECAppSpec` and `ReverseAppSpec` to align with crypto implementations. Streamline imports and update test logic for better clarity and maintainability.

* Refactor `PlainText` and `CipherText` to include manifest metadata, update encryption/decryption logic across crypto modules, and adjust serializers for consistency with the new structure.