### PR TITLE
Switch to immutable byte arrays and reorganize core package

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -112,10 +112,6 @@ lazy val `codec-upickle` = (project in file("codec-upickle"))
   .settings(codecUpickleSettings)
   .dependsOn(core)
 
-lazy val `crypto-javax` = (project in file("crypto-javax"))
-  .settings(cryptoCommonSettings("crypto-javax"))
-  .dependsOn(core)
-
 lazy val `crypto-bouncycastle` = (project in file("crypto-bouncycastle"))
   .settings(
     cryptoCommonSettings("crypto-bouncycastle") ++ Seq(
@@ -131,8 +127,7 @@ lazy val `crypto-test` = (project in file("crypto-test"))
     `codec-chill`,
     `codec-fst`,
     `codec-upickle`,
-    `crypto-bouncycastle`,
-    `crypto-javax`
+    `crypto-bouncycastle`
   )
 
 lazy val cryptic = (project in file("."))
@@ -151,7 +146,6 @@ lazy val cryptic = (project in file("."))
     `codec-chill`,
     `codec-fst`,
     `codec-upickle`,
-    `crypto-javax`,
     `crypto-bouncycastle`,
     `crypto-test`
   )

--- a/codec-chill/src/main/scala/cryptic/codec/Chill.scala
+++ b/codec-chill/src/main/scala/cryptic/codec/Chill.scala
@@ -22,7 +22,9 @@ object Chill extends Codec.Companion:
     KryoPool.withByteArrayOutputStream(10, new ScalaKryoInstantiator())
 
   given codec: [V] => Codec[V]:
-    def encode(v: V): PlainText = PlainText(kryoPool.toBytesWithClass(v))
+    def encode(v: V): PlainText = PlainText(
+      kryoPool.toBytesWithClass(v).immutable
+    )
     def decode(pt: PlainText): Try[V] = Try(
-      kryoPool.fromBytes(pt.bytes).asInstanceOf[V]
+      kryoPool.fromBytes(pt.bytes.mutable).asInstanceOf[V]
     )

--- a/codec-fst/src/main/scala/cryptic/codec/Fst.scala
+++ b/codec-fst/src/main/scala/cryptic/codec/Fst.scala
@@ -28,7 +28,7 @@ object Fst extends Codec.Companion:
   private val fst: FSTConfiguration =
     FSTConfiguration.createDefaultConfiguration()
   given codec: [V] => Codec[V]:
-    def encode(v: V): PlainText = PlainText(fst.asByteArray(v))
+    def encode(v: V): PlainText = PlainText(fst.asByteArray(v).immutable)
     def decode(pt: PlainText): Try[V] = Try(
-      fst.asObject(pt.bytes).asInstanceOf[V]
+      fst.asObject(pt.bytes.mutable).asInstanceOf[V]
     )

--- a/codec-upickle/src/main/scala/cryptic/codec/Upickle.scala
+++ b/codec-upickle/src/main/scala/cryptic/codec/Upickle.scala
@@ -16,5 +16,5 @@ object Upickle extends Codec.Companion:
   given codec: [V: {Writer, Reader}] => Codec[V]:
     def encode(v: V): PlainText = PlainText(write(v))
     def decode(pt: PlainText): Try[V] = Try(
-      read[V](pt.bytes)
+      read[V](pt.bytes.mutable)
     )

--- a/core/src/main/scala/cryptic/codec/default.scala
+++ b/core/src/main/scala/cryptic/codec/default.scala
@@ -15,44 +15,44 @@ object default extends Codec.Companion:
       if pt.bytes.isEmpty then Success(None)
       else summon[Codec[V]].decode(pt).map(Some(_))
 
-  given Codec[Array[Byte]]:
-    def encode(v: Array[Byte]): PlainText = PlainText(v)
-    def decode(pt: PlainText): Try[Array[Byte]] =
+  given Codec[IArray[Byte]]:
+    def encode(v: IArray[Byte]): PlainText = PlainText(v)
+    def decode(pt: PlainText): Try[IArray[Byte]] =
       Success(pt.bytes)
 
   given Codec[String]:
     def encode(v: String): PlainText = PlainText(v)
     def decode(pt: PlainText): Try[String] =
-      Success(new String(pt.bytes))
+      Success(new String(pt.bytes.mutable))
 
   given Codec[Int]:
-    def encode(v: Int): PlainText = 
+    def encode(v: Int): PlainText =
       val buffer = ByteBuffer.allocate(4)
       buffer.putInt(v)
-      PlainText(buffer.array())
+      PlainText(buffer.array().immutable)
     def decode(pt: PlainText): Try[Int] =
-      Try(ByteBuffer.wrap(pt.bytes).getInt)
+      Try(ByteBuffer.wrap(pt.bytes.mutable).getInt)
 
   given Codec[Long]:
-    def encode(v: Long): PlainText = 
+    def encode(v: Long): PlainText =
       val buffer = ByteBuffer.allocate(8)
       buffer.putLong(v)
-      PlainText(buffer.array())
+      PlainText(buffer.array().immutable)
     def decode(pt: PlainText): Try[Long] =
-      Try(ByteBuffer.wrap(pt.bytes).getLong)
+      Try(ByteBuffer.wrap(pt.bytes.mutable).getLong)
 
   given Codec[Float]:
-    def encode(v: Float): PlainText = 
+    def encode(v: Float): PlainText =
       val buffer = ByteBuffer.allocate(4)
       buffer.putFloat(v)
-      PlainText(buffer.array())
+      PlainText(buffer.array().immutable)
     def decode(pt: PlainText): Try[Float] =
-      Try(ByteBuffer.wrap(pt.bytes).getFloat)
+      Try(ByteBuffer.wrap(pt.bytes.mutable).getFloat)
 
   given Codec[Double]:
-    def encode(v: Double): PlainText = 
+    def encode(v: Double): PlainText =
       val buffer = ByteBuffer.allocate(8)
       buffer.putDouble(v)
-      PlainText(buffer.array())
+      PlainText(buffer.array().immutable)
     def decode(pt: PlainText): Try[Double] =
-      Try(ByteBuffer.wrap(pt.bytes).getDouble)
+      Try(ByteBuffer.wrap(pt.bytes.mutable).getDouble)

--- a/core/src/main/scala/cryptic/cryptic.scala
+++ b/core/src/main/scala/cryptic/cryptic.scala
@@ -95,6 +95,8 @@ extension (array: Array[Byte])
 
 extension (array: IArray[Byte])
   def mutable: Array[Byte] = IArray.wrapByteIArray(array).unsafeArray
+extension (array: IArray[Char])
+  def mutable: Array[Char] = IArray.wrapCharIArray(array).unsafeArray
 
 extension (buffer: ByteBuffer)
   def nextBytes(): Array[Byte] =

--- a/core/src/main/scala/cryptic/cryptic.scala
+++ b/core/src/main/scala/cryptic/cryptic.scala
@@ -4,35 +4,38 @@ import java.nio.ByteBuffer
 import scala.util.{Failure, Success, Try}
 import scala.reflect.ClassTag
 
-type Hash = Vector[Byte]
-type Manifest = Array[Byte]
+type Hash = IArray[Byte]
+type Signature = IArray[Byte]
+type Manifest = IArray[Byte]
 
 object Manifest:
-  val empty: Array[Byte] = Array.emptyByteArray
+  val empty: Manifest = IArray.emptyByteIArray
 
-case class PlainText(bytes: Array[Byte], manifest: Manifest = Manifest.empty):
-  //    override def toString: String = "\uD83D\uDD12"
+case class PlainText(bytes: IArray[Byte], manifest: Manifest = Manifest.empty):
+  // override def toString: String = "\uD83D\uDD12"
   override def equals(obj: Any): Boolean = obj match
     case other: PlainText =>
       manifest.sameElements(other.manifest) && bytes.sameElements(other.bytes)
     case _ => false
   override def hashCode: Int =
-    java.util.Arrays.hashCode(bytes) * 31 + java.util.Arrays.hashCode(
-      manifest
+    java.util.Arrays.hashCode(
+      bytes.mutable
+    ) * 31 + java.util.Arrays.hashCode(
+      manifest.mutable
     )
 
 object PlainText:
-  val empty: PlainText = PlainText(Array.emptyByteArray)
-  def apply(x: Array[Byte]): PlainText = new PlainText(x)
-  def apply(x: String): PlainText = apply(x.getBytes())
+  val empty: PlainText = PlainText(IArray.emptyByteIArray)
+  def apply(x: IArray[Byte]): PlainText = new PlainText(x)
+  def apply(x: String): PlainText = apply(x.getBytes().immutable)
   def hash(plainText: PlainText): Hash =
     import java.security.MessageDigest
     val digest = MessageDigest.getInstance("SHA-256")
-    digest.digest(plainText.bytes).toVector // Todo handle manifest?
+    digest.digest(plainText.bytes.mutable).immutable // Todo handle manifest?
 
-case class CipherText(bytes: Array[Byte]):
-  def buffer: ByteBuffer = ByteBuffer.wrap(bytes)
-  def split: Array[Array[Byte]] = buffer.split
+case class CipherText(bytes: IArray[Byte]):
+  def buffer: ByteBuffer = ByteBuffer.wrap(bytes.mutable)
+  def split: IArray[IArray[Byte]] = buffer.split
   override def equals(obj: scala.Any): Boolean = obj match
     case CipherText(other) ⇒ bytes.sameElements(other)
     case _ ⇒ false
@@ -40,17 +43,17 @@ case class CipherText(bytes: Array[Byte]):
     s"${getClass.getCanonicalName.split('.').last}(0x${bytes.map("%02x".format(_)).mkString})"
 
 object CipherText:
-  val Empty: CipherText = CipherText(Array.emptyByteArray)
-  def apply(array: Array[Byte], arrays: Array[Byte]*): CipherText =
+  val Empty: CipherText = CipherText(IArray.emptyByteIArray)
+  def apply(array: IArray[Byte], arrays: IArray[Byte]*): CipherText =
     val count = 1 + arrays.length
     val buffer = ByteBuffer.allocate(4 + count * 4 + arrays.foldLeft(0):
       case (length, bytes) => length + bytes.length)
     buffer.putInt(count)
-    buffer.nextBytes(array)
+    buffer.nextBytes(array.mutable)
     arrays.foldLeft(buffer):
-      case (buffer, bytes) => buffer.nextBytes(bytes)
-    new CipherText(buffer.array())
-  def unapplySeq(cipherText: CipherText): Option[Seq[Array[Byte]]] =
+      case (buffer, bytes) => buffer.nextBytes(bytes.mutable)
+    new CipherText(buffer.array().immutable)
+  def unapplySeq(cipherText: CipherText): Option[Seq[IArray[Byte]]] =
     Option(cipherText.split)
 
 type Encrypt = PlainText => CipherText
@@ -60,6 +63,9 @@ object Encrypt:
 type Decrypt = CipherText => Try[PlainText]
 object Decrypt:
   val Empty: Decrypt = _ ⇒ Success(PlainText.empty)
+
+type Sign = PlainText => Array[Byte]
+type Verify = Array[Byte] => Boolean
 
 trait Codec[V]:
   def encode(v: V): PlainText
@@ -84,6 +90,12 @@ given Codec[Nothing]:
 extension [V: Codec](value: V)
   def encrypted(using encrypt: Encrypt): Encrypted[V] = Encrypted(value)
 
+extension (array: Array[Byte])
+  def immutable: IArray[Byte] = IArray.unsafeFromArray(array)
+
+extension (array: IArray[Byte])
+  def mutable: Array[Byte] = IArray.wrapByteIArray(array).unsafeArray
+
 extension (buffer: ByteBuffer)
   def nextBytes(): Array[Byte] =
     val length = buffer.getInt()
@@ -94,11 +106,11 @@ extension (buffer: ByteBuffer)
   def nextBytes(bytes: Array[Byte]): ByteBuffer =
     buffer.putInt(bytes.length)
     buffer.put(bytes)
-  def split: Array[Array[Byte]] =
+  def split: IArray[IArray[Byte]] =
     val count = buffer.getInt()
-    val arrays = Array.ofDim[Array[Byte]](count)
-    for i <- 0 until count do arrays(i) = buffer.nextBytes()
-    arrays
+    val arrays = Array.ofDim[IArray[Byte]](count)
+    for i <- 0 until count do arrays(i) = buffer.nextBytes().immutable
+    IArray.unsafeFromArray(arrays)
 
 sealed abstract class Cryptic[V: Codec]:
   import Cryptic.*
@@ -209,6 +221,15 @@ sealed abstract class Cryptic[V: Codec]:
   ): Operation[W] =
     new OrElsed(this, alternative)
 object Cryptic:
+  export cryptic.{
+    encrypted,
+    Encrypted,
+    Encrypt,
+    Decrypt,
+    Codec,
+    PlainText,
+    CipherText
+  }
   import Encrypted.*
   sealed abstract class Operation[V: Codec] extends Cryptic[V]:
     def run(using encrypt: Encrypt, decrypt: Decrypt): Try[Encrypted[V]]
@@ -300,7 +321,7 @@ case class Encrypted[V: Codec](cipherText: CipherText) extends Cryptic[V]:
     * @return
     *   the byte array of the cipher text
     */
-  def bytes: Array[Byte] = cipherText.bytes
+  def bytes: IArray[Byte] = cipherText.bytes
 
   /** Checks if the option is non-empty (defined).
     *

--- a/core/src/main/scala/cryptic/crypto/Aes.scala
+++ b/core/src/main/scala/cryptic/crypto/Aes.scala
@@ -28,7 +28,7 @@ object Aes:
       s"Invalid keyspecLength: $keyspecLength. Allowed values are ${validKeyspecLenghts.mkString(", ")}."
     )
 
-  case class Salt(bytes: Array[Byte]) extends AnyVal:
+  case class Salt(bytes: IArray[Byte]) extends AnyVal:
     def length: Int = bytes.length
 
   /** Case class AESPassphrase for handling cryptographic passphrases.
@@ -36,13 +36,13 @@ object Aes:
     * @param bytes
     *   Array of bytes representing the passphrase.
     */
-  case class AESPassphrase(bytes: Array[Byte]):
-    def chars: Array[Char] = bytes.map(_.toChar)
-    override def toString: String = new String(bytes)
+  case class AESPassphrase(bytes: IArray[Byte]):
+    def chars: IArray[Char] = bytes.map(_.toChar)
+    override def toString: String = new String(bytes.mutable)
 
   object AESPassphrase:
     def apply(password: String): AESPassphrase = new AESPassphrase(
-      password.getBytes
+      password.getBytes.immutable
     )
 
   private def newCipher(using aesParams: AESParams): Cipher =
@@ -61,7 +61,7 @@ object Aes:
     val cipherText = cipher.doFinal(plainText.bytes.mutable)
     CipherText(
       plainText.manifest,
-      salt.bytes.immutable,
+      salt.bytes,
       initVector.immutable,
       cipherText.immutable
     )
@@ -71,7 +71,7 @@ object Aes:
       aesParams: AESParams
   ): Decrypt = (cipherText: CipherText) =>
     val IArray(manifest, salt, iv, bytes) = cipherText.split
-    val key = keygen(passphrase, Salt(salt.mutable))
+    val key = keygen(passphrase, Salt(salt))
     val cipher = newCipher
     cipher.init(Cipher.DECRYPT_MODE, key, new IvParameterSpec(iv.mutable))
     Try[PlainText](PlainText(cipher.doFinal(bytes.mutable).immutable, manifest))
@@ -94,8 +94,8 @@ object Aes:
     val factory = SecretKeyFactory.getInstance(aesParams.factoryAlgorithm)
     val keySpec =
       new PBEKeySpec(
-        passphrase.chars,
-        salt.bytes,
+        passphrase.chars.mutable,
+        salt.bytes.mutable,
         aesParams.keyspecIterationCount,
         aesParams.keyspecLength
       )
@@ -108,4 +108,4 @@ object Aes:
   private def generateSalt(length: Int): Salt =
     val salt = new Array[Byte](length)
     Aes.secureRandom.nextBytes(salt)
-    Salt(salt)
+    Salt(salt.immutable)

--- a/core/src/main/scala/cryptic/crypto/Caesar.scala
+++ b/core/src/main/scala/cryptic/crypto/Caesar.scala
@@ -19,7 +19,7 @@ object Caesar:
   case class Key(offset: Int):
     require(offset != 0)
   given encrypt(using key: Key): Encrypt = (plainText: PlainText) =>
-    val bytes = plainText.bytes.map(b ⇒ (b + key.offset).toByte)
+    val bytes = plainText.bytes.mutable.map(b ⇒ (b + key.offset).toByte).immutable
     CipherText(bytes)
   given decrypt(using key: Key): Decrypt = (cipherText: CipherText) =>
     Try[PlainText](

--- a/core/src/main/scala/cryptic/crypto/Rsa.scala
+++ b/core/src/main/scala/cryptic/crypto/Rsa.scala
@@ -18,17 +18,23 @@ import scala.util.Try
   *   Generates an RSA key pair with the specified size.
   */
 object Rsa:
+  export java.security.{KeyPair, KeyPairGenerator, PrivateKey, PublicKey}
   val cipher: Cipher = Cipher.getInstance("RSA")
   given encrypt(using key: PublicKey): Encrypt =
     (plainText: PlainText) =>
       cipher.init(Cipher.ENCRYPT_MODE, key)
-      CipherText(plainText.manifest, cipher.doFinal(plainText.bytes))
+      CipherText(
+        plainText.manifest,
+        cipher.doFinal(plainText.bytes.mutable).immutable
+      )
 
   given decrypt(using key: PrivateKey): Decrypt =
     (cipherText: CipherText) =>
-      val Array(manifest, bytes) = cipherText.split
+      val IArray(manifest, bytes) = cipherText.split
       cipher.init(Cipher.DECRYPT_MODE, key)
-      Try[PlainText](PlainText(cipher.doFinal(bytes), manifest))
+      Try[PlainText](
+        PlainText(cipher.doFinal(bytes.mutable).immutable, manifest)
+      )
 
   /** Generates a new RSA key pair with the specified key size.
     *

--- a/core/src/main/scala/cryptic/crypto/default.scala
+++ b/core/src/main/scala/cryptic/crypto/default.scala
@@ -1,0 +1,5 @@
+package cryptic
+package crypto
+
+object default:
+  export Rsa.{given, *}

--- a/core/src/main/scala/cryptic/default.scala
+++ b/core/src/main/scala/cryptic/default.scala
@@ -1,0 +1,6 @@
+package cryptic
+
+object default extends Codec.Companion:
+  export cryptic.Cryptic.{given, *}
+  export cryptic.codec.default.{given, *}
+  export cryptic.crypto.default.{given, *}

--- a/core/src/test/scala/app/DefaultAppSpec.scala
+++ b/core/src/test/scala/app/DefaultAppSpec.scala
@@ -1,0 +1,37 @@
+package app
+
+import org.scalatest.TryValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.{Success, Try}
+
+class DefaultAppSpec extends AnyFlatSpec with Matchers with TryValues:
+  import cryptic.default.{given, *}
+
+  val keyPair: KeyPair = keygen(2048)
+  given publicKey: PublicKey = keyPair.getPublic
+  given privateKey: PrivateKey = keyPair.getPrivate
+  val clear = "secret"
+  val encrypted: Encrypted[String] = clear.encrypted
+  val decrypted: Try[String] = encrypted.decrypted
+
+  "Cryptic" should "encrypt" in:
+    encrypted.bytes should not equal clear.getBytes
+
+  "Cryptic" should "decrypt" in:
+    decrypted.success shouldEqual Success(clear)
+
+  case class Person(id: Long, email: Encrypted[String])
+
+  val id = 17
+  val email = "martin@scalacrypto.org"
+  val person = Person(id, email.encrypted)
+
+  "Email" should "be encrypted" in:
+    person.email.bytes.unsafeArray should not equal email.getBytes()
+    person.email.contains(email) shouldBe true
+    person.toString should startWith("Person(17,Encrypted(CipherText(0x")
+
+  "Email" should "be decrypted" in:
+    person.email.decrypted.success shouldEqual Success(email)

--- a/core/src/test/scala/cryptic/codec/CodecSpec.scala
+++ b/core/src/test/scala/cryptic/codec/CodecSpec.scala
@@ -8,7 +8,7 @@ import scala.util.{Success, Try}
 
 class CodecSpec extends AnyFlatSpec with Matchers:
   import cryptic.codec.default.{*, given}
-  val bytes: Array[Byte] = Array[Byte](0, 1, 2, 3, 4, 5, 6)
+  val bytes: IArray[Byte] = IArray[Byte](0, 1, 2, 3, 4, 5, 6)
   val text = "kalle"
   val int = 17
   val long = 4711L
@@ -16,15 +16,15 @@ class CodecSpec extends AnyFlatSpec with Matchers:
   val float: Float = double.toFloat
   "Codec" should "encode simple types to plain text" in:
     bytes.encoded.bytes shouldEqual bytes
-    text.encoded.bytes shouldEqual text.getBytes
-    int.encoded.bytes shouldEqual Array[Byte](0,0,0,17)
-    long.encoded.bytes shouldEqual Array(0, 0, 0, 0, 0, 0, 18, 103)
-    float.encoded.bytes shouldEqual Array(64, 45, -8, 84)
-    double.encoded.bytes shouldEqual Array(64, 5, -65, 10, -117, 20, 87, 105)
+    text.encoded.bytes shouldEqual text.getBytes.immutable
+    int.encoded.bytes shouldEqual IArray[Byte](0, 0, 0, 17)
+    long.encoded.bytes shouldEqual IArray(0, 0, 0, 0, 0, 0, 18, 103)
+    float.encoded.bytes shouldEqual IArray(64, 45, -8, 84)
+    double.encoded.bytes shouldEqual IArray(64, 5, -65, 10, -117, 20, 87, 105)
 
   "Codec" should "decode PlainText to specified types" in:
-    def decode[V: Codec](pt: PlainText): Try[V] = (pt.decoded): Try[V]
-    decode[Array[Byte]](bytes.encoded) shouldEqual Success(bytes)
+    def decode[V: Codec](pt: PlainText): Try[V] = pt.decoded: Try[V]
+    decode[IArray[Byte]](bytes.encoded) shouldEqual Success(bytes)
     decode[String](text.encoded) shouldEqual Success(text)
     decode[Int](int.encoded) shouldEqual Success(int)
     decode[Long](long.encoded) shouldEqual Success(long)

--- a/core/src/test/scala/cryptic/crypto/AesSpec.scala
+++ b/core/src/test/scala/cryptic/crypto/AesSpec.scala
@@ -21,7 +21,7 @@ class AesSpec extends AnyFlatSpec with Matchers:
       case x ⇒ fail(s"does not decrypt: $x")
 
   "AES" should "hide plaintext" in:
-    new String(text.encrypted.bytes)
+    new String(text.encrypted.bytes.mutable)
       .contains(text.getBytes()) shouldBe false
 
   "AESParams keyspecLength" should

--- a/core/src/test/scala/cryptic/crypto/CaesarSpec.scala
+++ b/core/src/test/scala/cryptic/crypto/CaesarSpec.scala
@@ -20,7 +20,7 @@ class CaesarSpec extends AnyFlatSpec with Matchers:
       case x ⇒ fail(s"does not decrypt: $x")
 
   "Caesar Encrypted" should "hide plaintext" in:
-    new String(encrypted.bytes)
+    new String(encrypted.bytes.mutable)
       .contains(text) shouldBe false
 
   "Caesar key zero" should "not be valid" in:
@@ -28,4 +28,4 @@ class CaesarSpec extends AnyFlatSpec with Matchers:
       Caesar.Key(0)
 
   "Caesar Encrypted" should "be rotated" in:
-    encrypted.bytes shouldEqual "ojttf".getBytes
+    encrypted.bytes.mutable shouldEqual "ojttf".getBytes

--- a/core/src/test/scala/cryptic/crypto/ReverseSpec.scala
+++ b/core/src/test/scala/cryptic/crypto/ReverseSpec.scala
@@ -19,8 +19,8 @@ class ReverseSpec extends AnyFlatSpec with Matchers:
       case x ⇒ fail(s"does not decrypt: $x")
 
   "Reverse Encrypted" should "hide plaintext" in:
-    new String(encrypted.bytes)
+    new String(encrypted.bytes.mutable)
       .contains(text) shouldBe false
 
   "Reverse" should "be reversed" in:
-    encrypted.bytes shouldEqual text.reverse.getBytes
+    encrypted.bytes.mutable shouldEqual text.reverse.getBytes

--- a/core/src/test/scala/cryptic/crypto/RsaSpec.scala
+++ b/core/src/test/scala/cryptic/crypto/RsaSpec.scala
@@ -24,5 +24,5 @@ class RsaSpec extends AnyFlatSpec with Matchers:
       case x ⇒ fail(s"does not decrypt: $x")
 
   "RSA" should "hide plaintext" in:
-    new String(text.encrypted.bytes)
+    new String(text.encrypted.bytes.mutable)
       .contains(text.getBytes()) shouldBe false

--- a/crypto-bouncycastle/src/main/scala/cryptic/crypto/EllipticCurve.scala
+++ b/crypto-bouncycastle/src/main/scala/cryptic/crypto/EllipticCurve.scala
@@ -18,13 +18,18 @@ object EllipticCurve:
   given encrypt(using key: PublicKey): Encrypt =
     (plainText: PlainText) =>
       cipher.init(Cipher.ENCRYPT_MODE, key)
-      CipherText(plainText.manifest, cipher.doFinal(plainText.bytes))
+      CipherText(
+        plainText.manifest,
+        cipher.doFinal(plainText.bytes.mutable).immutable
+      )
 
   given decrypt(using key: PrivateKey): Decrypt =
     (cipherText: CipherText) =>
-      val Array(manifest, bytes) = cipherText.split
+      val IArray(manifest, bytes) = cipherText.split
       cipher.init(Cipher.DECRYPT_MODE, key)
-      Try[PlainText](PlainText(cipher.doFinal(bytes), manifest))
+      Try[PlainText](
+        PlainText(cipher.doFinal(bytes.mutable).immutable, manifest)
+      )
 
   /** Generates a new elliptic curve key pair.
     *

--- a/crypto-bouncycastle/src/test/scala/cryptic/crypto/EllipticCurveSpec.scala
+++ b/crypto-bouncycastle/src/test/scala/cryptic/crypto/EllipticCurveSpec.scala
@@ -26,5 +26,5 @@ class EllipticCurveSpec extends AnyFlatSpec with Matchers:
       case x ⇒ fail(s"does not decrypt: $x")
 
   "EC" should "hide the plain text" in:
-    new String(text.encrypted.bytes)
+    new String(text.encrypted.bytes.mutable)
       .contains(text.getBytes()) shouldBe false

--- a/crypto-test/src/test/scala/cryptic/GettingStartedSpec.scala
+++ b/crypto-test/src/test/scala/cryptic/GettingStartedSpec.scala
@@ -42,7 +42,7 @@ class GettingStartedSpec extends AnyFlatSpec with Matchers:
       user
 
     // #access
-    val bytes: Array[Byte] = user.email.bytes
+    val bytes: IArray[Byte] = user.email.bytes
     // #access
 
     val loweredEmailOp: Cryptic.Operation[EmailAddress] =

--- a/crypto-test/src/test/scala/cryptic/crypto/CryptoSpecBase.scala
+++ b/crypto-test/src/test/scala/cryptic/crypto/CryptoSpecBase.scala
@@ -19,12 +19,12 @@ trait CryptoSpecBase extends AnyFlatSpecLike with Matchers with TryValues:
     case class Foo(clear: String, secret: Encrypted[String])
     val foo =
       Foo("clear", "secret".encrypted)
-    foo.secret.bytes shouldNot be(null)
+    foo.secret.bytes.mutable shouldNot be(null)
     foo.secret.decrypted shouldEqual Success("secret")
   "Encrypted bytes" should "be callable without decrypt in scope" in:
     given e: Encrypt = encrypt
     val encrypted = Encrypted[String]("secret")
-    encrypted.bytes shouldNot be(null)
+    encrypted.bytes.mutable shouldNot be(null)
   "Encrypted same plain text " should "have different cipher text " in:
     given e: Encrypt = encrypt
     val enc1 = "nisse".encrypted


### PR DESCRIPTION
### Description

This pull request makes several improvements to the codebase to enhance immutability and simplify module structure:

- Replaced `Array[Byte]` with `IArray[Byte]` for ensuring immutability.
- Introduced a default object in the core module that exports all necessary types from the cryptic package, along with default codec and crypto objects.
- Moved all `javax` cryptographic implementations into the core package, eliminating the need for a separate `javax` module.

These changes aim to improve maintainability, stability, and usability of the library.