### PR TITLE
Refactor Encrypted API and add MultiCaesar cipher for tests

### DIFF
--- a/codec-chill/src/main/scala/cryptic/codec/Chill.scala
+++ b/codec-chill/src/main/scala/cryptic/codec/Chill.scala
@@ -22,8 +22,8 @@ object Chill extends Codec.Companion:
     KryoPool.withByteArrayOutputStream(10, new ScalaKryoInstantiator())
 
   given codec: [V] => Codec[V]:
-    def encode(v: V): PlainText = PlainText(
-      kryoPool.toBytesWithClass(v).immutable
+    def encode(v: V, manifest: Manifest): PlainText = PlainText(
+      kryoPool.toBytesWithClass(v).immutable, manifest
     )
     def decode(pt: PlainText): Try[V] = Try(
       kryoPool.fromBytes(pt.bytes.mutable).asInstanceOf[V]

--- a/codec-fst/src/main/scala/cryptic/codec/Fst.scala
+++ b/codec-fst/src/main/scala/cryptic/codec/Fst.scala
@@ -28,7 +28,8 @@ object Fst extends Codec.Companion:
   private val fst: FSTConfiguration =
     FSTConfiguration.createDefaultConfiguration()
   given codec: [V] => Codec[V]:
-    def encode(v: V): PlainText = PlainText(fst.asByteArray(v).immutable)
+    def encode(v: V, manifest: Manifest): PlainText =
+      PlainText(fst.asByteArray(v).immutable, manifest)
     def decode(pt: PlainText): Try[V] = Try(
       fst.asObject(pt.bytes.mutable).asInstanceOf[V]
     )

--- a/codec-upickle/src/main/scala/cryptic/codec/Upickle.scala
+++ b/codec-upickle/src/main/scala/cryptic/codec/Upickle.scala
@@ -14,7 +14,7 @@ import scala.util.Try
   */
 object Upickle extends Codec.Companion:
   given codec: [V: {Writer, Reader}] => Codec[V]:
-    def encode(v: V): PlainText = PlainText(write(v))
+    def encode(v: V, manifest: Manifest): PlainText = PlainText(write(v), manifest)
     def decode(pt: PlainText): Try[V] = Try(
       read[V](pt.bytes.mutable)
     )

--- a/core/src/main/scala/cryptic/codec/default.scala
+++ b/core/src/main/scala/cryptic/codec/default.scala
@@ -7,52 +7,52 @@ import scala.util.Success
 
 object default extends Codec.Companion:
   given optionCodec: [V: Codec] => Codec[Option[V]]:
-    def encode(v: Option[V]): PlainText =
+    def encode(v: Option[V], manifest: Manifest): PlainText =
       v match
-        case Some(value) => summon[Codec[V]].encode(value)
+        case Some(value) => summon[Codec[V]].encode(value, manifest)
         case None        => PlainText.empty
     def decode(pt: PlainText): Try[Option[V]] =
       if pt.bytes.isEmpty then Success(None)
       else summon[Codec[V]].decode(pt).map(Some(_))
 
   given Codec[IArray[Byte]]:
-    def encode(v: IArray[Byte]): PlainText = PlainText(v)
+    def encode(v: IArray[Byte], manifest: Manifest): PlainText = PlainText(v, manifest)
     def decode(pt: PlainText): Try[IArray[Byte]] =
       Success(pt.bytes)
 
   given Codec[String]:
-    def encode(v: String): PlainText = PlainText(v)
+    def encode(v: String, manifest: Manifest): PlainText = PlainText(v, manifest)
     def decode(pt: PlainText): Try[String] =
       Success(new String(pt.bytes.mutable))
 
   given Codec[Int]:
-    def encode(v: Int): PlainText =
+    def encode(v: Int, manifest: Manifest): PlainText =
       val buffer = ByteBuffer.allocate(4)
       buffer.putInt(v)
-      PlainText(buffer.array().immutable)
+      PlainText(buffer.array().immutable, manifest)
     def decode(pt: PlainText): Try[Int] =
       Try(ByteBuffer.wrap(pt.bytes.mutable).getInt)
 
   given Codec[Long]:
-    def encode(v: Long): PlainText =
+    def encode(v: Long, manifest: Manifest): PlainText =
       val buffer = ByteBuffer.allocate(8)
       buffer.putLong(v)
-      PlainText(buffer.array().immutable)
+      PlainText(buffer.array().immutable, manifest)
     def decode(pt: PlainText): Try[Long] =
       Try(ByteBuffer.wrap(pt.bytes.mutable).getLong)
 
   given Codec[Float]:
-    def encode(v: Float): PlainText =
+    def encode(v: Float, manifest: Manifest): PlainText =
       val buffer = ByteBuffer.allocate(4)
       buffer.putFloat(v)
-      PlainText(buffer.array().immutable)
+      PlainText(buffer.array().immutable, manifest)
     def decode(pt: PlainText): Try[Float] =
       Try(ByteBuffer.wrap(pt.bytes.mutable).getFloat)
 
   given Codec[Double]:
-    def encode(v: Double): PlainText =
+    def encode(v: Double, manifest: Manifest): PlainText =
       val buffer = ByteBuffer.allocate(8)
       buffer.putDouble(v)
-      PlainText(buffer.array().immutable)
+      PlainText(buffer.array().immutable, manifest)
     def decode(pt: PlainText): Try[Double] =
       Try(ByteBuffer.wrap(pt.bytes.mutable).getDouble)

--- a/core/src/main/scala/cryptic/crypto/Aes.scala
+++ b/core/src/main/scala/cryptic/crypto/Aes.scala
@@ -1,7 +1,6 @@
 package cryptic
 package crypto
 
-import java.nio.ByteBuffer
 import java.security.SecureRandom
 import java.security.spec.AlgorithmParameterSpec
 import javax.crypto.spec.{
@@ -11,7 +10,7 @@ import javax.crypto.spec.{
   SecretKeySpec
 }
 import javax.crypto.{Cipher, SecretKey, SecretKeyFactory}
-import scala.util.{Failure, Try}
+import scala.util.Try
 
 /** Object AES provides encryption and decryption utilities using the AES
   * algorithm. The functions provided allow encryption of plaintext into
@@ -107,12 +106,12 @@ object Aes:
     val iv = aesParams.iv
     val ivSpec = aesParams.paramSpec(iv)
     cipher.init(Cipher.ENCRYPT_MODE, key, ivSpec)
-    val cipherText = cipher.doFinal(plainText.bytes.mutable).immutable
+    val cipherText = cipher.doFinal(plainText.bytes.mutable)
     CipherText(
       plainText.manifest,
       salt.bytes,
       iv.immutable,
-      cipherText
+      cipherText.immutable
     )
 
   given decrypt(using

--- a/core/src/main/scala/cryptic/crypto/MultiCaesar.scala
+++ b/core/src/main/scala/cryptic/crypto/MultiCaesar.scala
@@ -1,0 +1,53 @@
+package cryptic
+package crypto
+
+import java.nio.ByteBuffer
+import scala.util.Try
+
+/** NOTE This crypto is only for testing, use a proper algorithm
+  *
+  * The `Caesar` object provides encryption and decryption functionality using
+  * the Caesar cipher. It includes methods to generate keys, and given methods
+  * to encrypt and decrypt text using a specified key.
+  *
+  * The Caesar cipher is a type of substitution cipher in which each letter in
+  * the plaintext is shifted a certain number of places down or up the alphabet
+  * based on the given offset.
+  *
+  * The `Key` case class ensures that the offset is non-zero.
+  */
+object MultiCaesar:
+  case class Keys(offsets: Map[Int, Int]):
+    require(offsets.nonEmpty, "Offsets map cannot be empty")
+    require(offsets.forall(_._2 != 0), "Offsets cannot be zero")
+    def add(keyId: Int, offset: Int): Keys =
+      copy(offsets = offsets + (keyId -> offset))
+    def get(keyId: Int): Int =
+      offsets.getOrElse(
+        keyId,
+        throw new NoSuchElementException(s"Key ID $keyId not found")
+      )
+  object Keys:
+    def apply(offsets: (Int, Int)*): Keys =
+      Keys(offsets.toMap)
+  given encrypt(using keys: Keys): Encrypt =
+    (plainText: PlainText) =>
+      val offset = keys.get(plainText.manifest.toKeyId)
+      val bytes =
+        plainText.bytes.mutable
+          .map: b =>
+            (b + offset).toByte
+          .immutable
+      CipherText(plainText.manifest, bytes)
+  given decrypt(using keys: Keys): Decrypt = (cipherText: CipherText) =>
+    val IArray(manifest, bytes) = cipherText.split
+    Try[PlainText](
+      PlainText(bytes.map(b => (b - keys.offsets(manifest.toKeyId)).toByte))
+    )
+
+  def keygen(keyId: Int, offset: Int): Keys = Keys(keyId -> offset)
+extension (n: Int)
+  def toManifest: IArray[Byte] =
+    ByteBuffer.allocate(4).putInt(n).array().immutable
+extension (bytes: IArray[Byte])
+  def toKeyId: Int = ByteBuffer.wrap(bytes.mutable).getInt

--- a/core/src/test/scala/app/ReverseAppSpec.scala
+++ b/core/src/test/scala/app/ReverseAppSpec.scala
@@ -12,7 +12,7 @@ class ReverseAppSpec extends AnyFlatSpec with Matchers with TryValues:
   import cryptic.crypto.Reverse.given
 
   val clear = "secret"
-  val encrypted: Encrypted[String] = Encrypted(clear)
+  val encrypted: Encrypted[String] = clear.encrypted
   val decrypted: Try[String] = encrypted.decrypted
 
   "Cryptic" should "encrypt" in:

--- a/core/src/test/scala/cryptic/EncryptedSpec.scala
+++ b/core/src/test/scala/cryptic/EncryptedSpec.scala
@@ -19,7 +19,7 @@ class EncryptedSpec extends AnyFlatSpec with Matchers with TryValues:
   import cryptic.crypto.Reverse.given
 
   private val clear = "nisse"
-  private val enc1: Encrypted[String] = Encrypted(clear)
+  private val enc1: Encrypted[String] = clear.encrypted
   private val emptyString: Encrypted[String] = Encrypted.empty[String]
 
   "Case class with encrypted members" should "encrypt and decrypt" in:
@@ -28,13 +28,13 @@ class EncryptedSpec extends AnyFlatSpec with Matchers with TryValues:
     foo.secret.bytes shouldEqual Array(116, 101, 114, 99, 101, 115)
     foo.secret.decrypted shouldEqual Success("secret")
   "Encrypted bytes" should "be callable without decrypt in scope" in:
-    val e = Encrypted[String]("secret")
+    val e = "secret".encrypted
     e.bytes shouldEqual Array(116, 101, 114, 99, 101, 115)
   "Encrypted" should "have same value in encrypted space" in:
-    val enc2 = Encrypted(clear)
+    val enc2 = clear.encrypted
     enc1 shouldEqual enc2
   "Encrypted" should "not equal different values" in:
-    val enc2 = Encrypted("kalle")
+    val enc2 = "kalle".encrypted
     (enc1 == enc2) shouldBe false
   "Encrypted" should "have exists" in:
     enc1.exists(_ == clear) shouldBe true

--- a/core/src/test/scala/cryptic/crypto/CaesarSpec.scala
+++ b/core/src/test/scala/cryptic/crypto/CaesarSpec.scala
@@ -13,7 +13,7 @@ class CaesarSpec extends AnyFlatSpec with Matchers:
   given key1: Key = Caesar.Key(1)
 
   private val text = "nisse"
-  private val encrypted = Encrypted(text)
+  private val encrypted = text.encrypted
   "Caesar Encrypted" should "support encryption and decryption" in:
     encrypted.decrypted match
       case Success(decrypted) ⇒ decrypted shouldEqual text

--- a/core/src/test/scala/cryptic/crypto/MultiCaesarSpec.scala
+++ b/core/src/test/scala/cryptic/crypto/MultiCaesarSpec.scala
@@ -1,0 +1,33 @@
+package cryptic
+package crypto
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Success
+
+class MultiCaesarSpec extends AnyFlatSpec with Matchers:
+  import MultiCaesar.{*, given}
+  import cryptic.codec.default.given
+  given keys: Keys = MultiCaesar.Keys(1 -> 2, 12 -> 1)
+
+  private val text = "nisse"
+  private val encrypted = text.encrypted(12.toManifest)
+  "MultiCaesar Encrypted" should "support encryption and decryption" in:
+    encrypted.decrypted match
+      case Success(decrypted) ⇒ decrypted shouldEqual text
+      case x ⇒ fail(s"does not decrypt: $x")
+
+  "MultiCaesar Encrypted" should "hide plaintext" in:
+    new String(encrypted.bytes.mutable)
+      .contains(text) shouldBe false
+
+  "MultiCaesar key zero" should "not be valid" in:
+    assertThrows[IllegalArgumentException]:
+      MultiCaesar.Keys(1 -> 0)
+
+  "MultiCaesar encrypted" should "be rotated" in:
+    encrypted.bytes.mutable shouldEqual IArray.join(
+      12.toManifest,
+      "ojttf".getBytes.immutable
+    )

--- a/core/src/test/scala/cryptic/crypto/ReverseSpec.scala
+++ b/core/src/test/scala/cryptic/crypto/ReverseSpec.scala
@@ -11,7 +11,7 @@ class ReverseSpec extends AnyFlatSpec with Matchers:
   import Reverse.{*, given}
 
   private val text = "nisse"
-  private val encrypted: Encrypted[String] = Encrypted(text)
+  private val encrypted: Encrypted[String] = text.encrypted
 
   "Reverse Encrypted" should "support encryption and decryption" in:
     encrypted.decrypted match

--- a/crypto-test/src/test/scala/cryptic/EncryptedSpecBase.scala
+++ b/crypto-test/src/test/scala/cryptic/EncryptedSpecBase.scala
@@ -34,10 +34,10 @@ trait EncryptedSpecBase extends AnyFlatSpec with Matchers with EitherValues:
     val pending: Cryptic[String] = encrypted.map(_.toUpperCase)
     pending.decrypted shouldEqual Success("SECRET")
   "Encrypted without a decryption key" should "have the same value in encrypted space" in:
-    val enc1 = Encrypted("nisse")
-    val enc2 = Encrypted("nisse")
+    val enc1 = "nisse".encrypted
+    val enc2 = "nisse".encrypted
     enc1 shouldEqual enc2
   "Encrypted values" should "not be equal" in:
-    val enc1 = Encrypted("nisse")
-    val enc2 = Encrypted("kalle")
+    val enc1 = "nisse".encrypted
+    val enc2 = "kalle".encrypted
     (enc1 == enc2) shouldBe false

--- a/crypto-test/src/test/scala/cryptic/crypto/CryptoSpecBase.scala
+++ b/crypto-test/src/test/scala/cryptic/crypto/CryptoSpecBase.scala
@@ -23,7 +23,7 @@ trait CryptoSpecBase extends AnyFlatSpecLike with Matchers with TryValues:
     foo.secret.decrypted shouldEqual Success("secret")
   "Encrypted bytes" should "be callable without decrypt in scope" in:
     given e: Encrypt = encrypt
-    val encrypted = Encrypted[String]("secret")
+    val encrypted = "secret".encrypted
     encrypted.bytes.mutable shouldNot be(null)
   "Encrypted same plain text " should "have different cipher text " in:
     given e: Encrypt = encrypt
@@ -32,8 +32,8 @@ trait CryptoSpecBase extends AnyFlatSpecLike with Matchers with TryValues:
     enc1 shouldNot equal(enc2)
   "Different encrypted plain texts" should "have different encrypted values" in:
     given e: Encrypt = encrypt
-    val enc1 = Encrypted("nisse")
-    val enc2 = Encrypted("kalle")
+    val enc1 = "nisse".encrypted
+    val enc2 = "kalle".encrypted
     (enc1 == enc2) shouldBe false
   "Pending operations " should " be ran when decrypting" in:
     val encrypted: Encrypted[String] =


### PR DESCRIPTION
- Refactored the `Encrypted` API to use extension methods, improving code readability.  
- Added support for `Manifest` in encoding and encryption functions.  
- Introduced the `MultiCaesar` cipher for use in testing scenarios.  