### PR TITLE
Simplify ECIES cipher initialization in `EllipticCurve` 

### DIFF
--- a/crypto-bouncycastle/src/main/scala/cryptic/crypto/EllipticCurve.scala
+++ b/crypto-bouncycastle/src/main/scala/cryptic/crypto/EllipticCurve.scala
@@ -39,6 +39,6 @@ object EllipticCurve extends Asymmetric:
         nonce
       )
 
-    val cipher = Cipher.getInstance("ECIESwithAES-CBC/NONE/PKCS7Padding", "BC")
+    val cipher = Cipher.getInstance("ECIES", "BC")
     cipher.init(mode, key, iesParams)
     cipher


### PR DESCRIPTION
by removing padding specification.
Made decryption fail.